### PR TITLE
app/riot-native: adjust link local address regex to currently provided output

### DIFF
--- a/app/riot_native.py
+++ b/app/riot_native.py
@@ -89,7 +89,7 @@ class RIOTNativeApp(BaseApplication):
             self.pid = p.pid
             print("Started node at localhost:%u" % self.terminal_port, file=sys.stderr)
             match = self.input("ifconfig",
-                    "inet6 addr: (fe80:[0-9a-f:]+)/64  scope: local")
+                    "inet6 addr: (fe80:[0-9a-f:]+)  scope: local")
             if match:
                 self.link_local_addr = match.group(1).decode()
         except subprocess.CalledProcessError:


### PR DESCRIPTION
Currently the regex rule to retrieve the link local address from a RIOT instance expects the prefix length after the address. RIOT currently doesn't output this in the output. This PR adjusts the regex to not expect the prefix length.

example output from RIOT:
```
> ifconfig
Iface  7  HWaddr: 4b:95  Channel: 26  NID: 0x23
          Long HWaddr: 00:5a:45:50:75:00:4b:95 
          MTU:1280  HL:64  RTR  
          IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::25a:4550:7500:4b95  scope: local  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff00:4b95
          inet6 group: ff02::1a
          
          Statistics for Layer 2
            RX packets 0  bytes 0
            TX packets 5 (Multicast: 5)  bytes 18
            TX succeeded 9 errors 0
          Statistics for IPv6
            RX packets 0  bytes 0
            TX packets 5 (Multicast: 5)  bytes 306
            TX succeeded 5 errors 0
```
