### PR TITLE
app/riot-native: adjust riot args to expectations

### DIFF
--- a/app/riot_native.py
+++ b/app/riot_native.py
@@ -82,7 +82,8 @@ class RIOTNativeApp(BaseApplication):
         return self.name
 
     def start(self, args=[]):
-        command = "socat EXEC:'%s -zlp %u',end-close,stderr,pty TCP-L:%u,reuseaddr,fork" \
+
+        command = "socat EXEC:'%s -z [::1]\:%u\,[::1]\:17754 ',end-close,stderr,pty TCP-L:%u,reuseaddr,fork" \
                     % (self.filename, self.zep_port, self.terminal_port)
         try:
             p = subprocess.Popen(command, shell=True)


### PR DESCRIPTION
Currently the RIOT instance started with socat crashes due to the `-z`/`--zep` argument not adhering to the expected syntax. This PR adjusts this to `<localhost>:<localport>,<remotehost>:<remoteport>`.

I've chosen to hardcode most of the variables (usage of `::1` and the zep server port) for now, mostly because the whole application doesn't seem to offer a lot of choice here.