### PR TITLE
mesh-riot: access mesh graph as list instead of dict

### DIFF
--- a/zep_mesh_riot_native.py
+++ b/zep_mesh_riot_native.py
@@ -62,7 +62,7 @@ def main():
             mesh.add_node(node)
             apps.append(app)
         for e in template.edges():
-            edge = (mesh.nodes()[e[0]], mesh.nodes()[e[1]])
+            edge = (list(mesh)[e[0]], list(mesh)[e[1]])
             mesh.add_edge(*edge)
 
     zep_server = Server(mesh=mesh, dump=args.dump_pcap)


### PR DESCRIPTION
`mesh.nodes()` offers only functionality to be accessed in a dict like maner, but not with list indices. As documented [here](https://github.com/networkx/networkx/blob/master/networkx/classes/graph.py#L674), the way to get a list of all nodes in a graph is to use `list(G.nodes)` or `list(G)`. Their documentation is IMHO a bit confusing on this because all their examples use numbers as node names, thus `G.nodes[n]` works then. This is not the case here unfortunately.